### PR TITLE
Add SyliusRefundPlugin migrations dependency

### DIFF
--- a/src/DependencyInjection/BitBagSyliusAdyenExtension.php
+++ b/src/DependencyInjection/BitBagSyliusAdyenExtension.php
@@ -32,7 +32,7 @@ final class BitBagSyliusAdyenExtension extends ConfigurableExtension implements 
 
         $container->prependExtensionConfig('sylius_labs_doctrine_migrations_extra', [
             'migrations' => [
-                'BitBag\SyliusAdyenPlugin\Migrations' => ['Sylius\Bundle\CoreBundle\Migrations'],
+                'BitBag\SyliusAdyenPlugin\Migrations' => ['Sylius\Bundle\CoreBundle\Migrations', 'Sylius\RefundPlugin\Migrations'],
             ],
         ]);
     }


### PR DESCRIPTION
Hi guys!

Without it, migrations bundle tries to execute Adyen migrations before Refund migrations, and fail because of foreign keys pointing to Refund tables.

Thank you!