### PR TITLE
Auto capture implementation

### DIFF
--- a/src/Bus/PaymentCommandFactory.php
+++ b/src/Bus/PaymentCommandFactory.php
@@ -24,19 +24,26 @@ final class PaymentCommandFactory implements PaymentCommandFactoryInterface
 
     /** @var EventCodeResolverInterface */
     private $eventCodeResolver;
+    private string $captureMethod;
 
     public function __construct(
         EventCodeResolverInterface $eventCodeResolver,
+        string $captureMethod,
         array $mapping = []
     ) {
         $this->mapping = array_merge_recursive(self::MAPPING, $mapping);
         $this->eventCodeResolver = $eventCodeResolver;
+        $this->captureMethod = $captureMethod;
     }
 
     private function createObject(string $eventName, PaymentInterface $payment): PaymentLifecycleCommand
     {
         if (!isset($this->mapping[$eventName])) {
             throw new UnmappedAdyenActionException(sprintf('Event "%s" has no handler registered', $eventName));
+        }
+
+        if ($eventName === EventCodeResolverInterface::AUTHORIZATION && $this->captureMethod === self::CAPTURE_METHOD_AUTO) {
+            $eventName = EventCodeResolverInterface::CAPTURE;
         }
 
         $class = (string) $this->mapping[$eventName];

--- a/src/Bus/PaymentCommandFactoryInterface.php
+++ b/src/Bus/PaymentCommandFactoryInterface.php
@@ -22,6 +22,7 @@ use Sylius\Component\Core\Model\PaymentInterface;
 
 interface PaymentCommandFactoryInterface
 {
+    public const CAPTURE_METHOD_AUTO = 'auto';
     public const MAPPING = [
         'authorisation' => AuthorizePayment::class,
         'payment_status_received' => PaymentStatusReceived::class,

--- a/src/DependencyInjection/BitBagSyliusAdyenExtension.php
+++ b/src/DependencyInjection/BitBagSyliusAdyenExtension.php
@@ -22,6 +22,7 @@ final class BitBagSyliusAdyenExtension extends ConfigurableExtension implements 
     public const TRANSPORT_FACTORY_ID = 'bitbag.sylius_adyen_plugin.client.adyen_transport_factory';
 
     public const SUPPORTED_PAYMENT_METHODS_LIST = 'bitbag.sylius_adyen_plugin.supported_payment_methods';
+    public const SUPPORTED_CAPTURE_METHODS = 'bitbag.sylius_adyen_plugin.capture_method';
 
     public function prepend(ContainerBuilder $container): void
     {
@@ -48,6 +49,8 @@ final class BitBagSyliusAdyenExtension extends ConfigurableExtension implements 
         if (null !== $config['logger']) {
             $container->setAlias('bitbag.sylius_adyen_plugin.logger', (string) $config['logger']);
         }
+
+        $container->setParameter(self::SUPPORTED_CAPTURE_METHODS, $config['capture_method']);
 
         // fallback for previous version
         if (!$container->has('sylius.command_bus')) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,10 +16,11 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 final class Configuration implements ConfigurationInterface
 {
     public const DEFAULT_LOGGER = 'logger';
-
     public const DEFAULT_PAYMENT_METHODS = [
         'scheme', 'dotpay', 'ideal', 'alipay', 'applepay', 'blik', 'amazonpay', 'sepadirectdebit',
     ];
+    public const CAPTURE_METHODS = ['auto', 'delayed_manual'];
+    public const DEFAULT_CAPTURE_METHOD = 'delayed_manual';
 
     public function getConfigTreeBuilder(): TreeBuilder
     {
@@ -40,7 +41,13 @@ final class Configuration implements ConfigurationInterface
                     ->treatTrueLike(self::DEFAULT_LOGGER)
                     ->defaultNull()
                 ->end()
-
+                ->scalarNode('capture_method')
+                    ->defaultValue(self::DEFAULT_CAPTURE_METHOD)
+                    ->validate()
+                        ->ifNotInArray(self::CAPTURE_METHODS)
+                        ->thenInvalid('Invalid config value %s should be one of: '.implode(', ', self::CAPTURE_METHODS))
+                    ->end()
+                ->end()
             ->end()
             ->beforeNormalization()
             ->always(static function ($arg) {

--- a/src/Resolver/Payment/EventCodeResolverInterface.php
+++ b/src/Resolver/Payment/EventCodeResolverInterface.php
@@ -15,7 +15,6 @@ use BitBag\SyliusAdyenPlugin\Resolver\Notification\Struct\NotificationItemData;
 interface EventCodeResolverInterface
 {
     public const CAPTURE = 'capture';
-
     public const AUTHORIZATION = 'authorisation';
 
     public const PAYMENT_METHOD_TYPES = [

--- a/src/Resources/config/services/bus.xml
+++ b/src/Resources/config/services/bus.xml
@@ -43,6 +43,7 @@
             id="bitbag.sylius_adyen_plugin.bus.payment_command_factory"
         >
             <argument type="service" id="bitbag.sylius_adyen_plugin.resolver.payment.event_code_resolver"/>
+            <argument>%bitbag.sylius_adyen_plugin.capture_method%</argument>
         </service>
 
         <service


### PR DESCRIPTION
Adyens default setup is to auto capture a payment directly after a successful 'authorisation'.
https://docs.adyen.com/online-payments/capture/

Sylius by default require the admin to complete the order payment with a Adyen 'capture'

This implementation reflex the default behavior in Adyen and set the payment state directly to 'complete'
Thus it saves a manual order payment 'complete' action and also an API 'capture' request

I'm discovering Adyen but it seems logical and right... ?