### PR TITLE
Add Bizum within the allowed payment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ It supports all methods available to [drop-in](https://docs.adyen.com/online-pay
 | **Payments** |
 | [Payment dropin](https://docs.adyen.com/online-payments/web-drop-in) | Yes |
 | [Card payments](https://docs.adyen.com/payment-methods/cards) | Yes |
+| [Bizum](https://docs.adyen.com/payment-methods/bizum) (Spain only) | Yes |
 | [3D Secure](https://docs.adyen.com/online-payments/3d-secure) | Yes |
 | **Wallet payments** |
 | [WeChat Pay](https://docs.adyen.com/payment-methods/wechat-pay) | Yes |

--- a/src/Client/ClientPayloadFactory.php
+++ b/src/Client/ClientPayloadFactory.php
@@ -33,7 +33,7 @@ final class ClientPayloadFactory implements ClientPayloadFactoryInterface
     /** @var RequestStack */
     private $requestStack;
 
-    /** @var array */
+    /** @var string[] */
     private $allowedMethodsList = [
         'ideal',
         'paypal',
@@ -42,6 +42,7 @@ final class ClientPayloadFactory implements ClientPayloadFactoryInterface
         'googlepay',
         'alipay',
         'twint',
+        'bizum',
         'blik',
         'dotpay',
         'scheme',


### PR DESCRIPTION
Hello, I am wondering if it would be possible to add support for a very popular payment method in Spain called Bizum and already well supported by Adyen: https://docs.adyen.com/payment-methods/bizum/

----

This PR includes Bizum within the list of allowed payment methods for this library.

Bizum is a quite popular mobile payment solution in Spain. It enables users to make instant payments and transfers using their mobile phone numbers. Bizum is integrated with most major Spanish banks, providing a seamless and secure payment experience.

This addition will allow merchants operating in Spain to set up an Adyent payment in their Sylius e-commerce with capabilities to offer Bizum for their Spanish zones.

Bizum's main features:

* Instant Payments: Allows users to make real-time payments via Bizum. Money is instantly transferred
* Mobile Integration: Payments are facilitated using mobile phone numbers. These numbers are properly linked to the users' bank accounts
* Wide Bank Support: Compatible with the main banks that operate in Spain, including Santander, BBVA, CaixaBank and ING

What do you think about this inclusion? Could it be possible to merge soon?

Thanks in advance,