### PR TITLE
Process notification payloads with undefined items

### DIFF
--- a/src/Controller/Shop/ProcessNotificationsAction.php
+++ b/src/Controller/Shop/ProcessNotificationsAction.php
@@ -12,9 +12,10 @@ declare(strict_types=1);
 namespace BitBag\SyliusAdyenPlugin\Controller\Shop;
 
 use BitBag\SyliusAdyenPlugin\Bus\DispatcherInterface;
-use BitBag\SyliusAdyenPlugin\Resolver\Notification\NotificationResolver;
+use BitBag\SyliusAdyenPlugin\Exception\NotificationItemsEmptyException;
 use BitBag\SyliusAdyenPlugin\Resolver\Notification\NotificationResolver\NoCommandResolvedException;
-use BitBag\SyliusAdyenPlugin\Resolver\Notification\NotificationToCommandResolver;
+use BitBag\SyliusAdyenPlugin\Resolver\Notification\NotificationResolverInterface;
+use BitBag\SyliusAdyenPlugin\Resolver\Notification\NotificationToCommandResolverInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,10 +27,10 @@ class ProcessNotificationsAction
     /** @var DispatcherInterface */
     private $dispatcher;
 
-    /** @var NotificationToCommandResolver */
+    /** @var NotificationToCommandResolverInterface */
     private $notificationCommandResolver;
 
-    /** @var NotificationResolver */
+    /** @var NotificationResolverInterface */
     private $notificationResolver;
 
     /** @var LoggerInterface */
@@ -37,8 +38,8 @@ class ProcessNotificationsAction
 
     public function __construct(
         DispatcherInterface $dispatcher,
-        NotificationToCommandResolver $notificationCommandResolver,
-        NotificationResolver $notificationResolver,
+        NotificationToCommandResolverInterface $notificationCommandResolver,
+        NotificationResolverInterface $notificationResolver,
         LoggerInterface $logger,
     ) {
         $this->dispatcher = $dispatcher;

--- a/src/Controller/Shop/ProcessNotificationsAction.php
+++ b/src/Controller/Shop/ProcessNotificationsAction.php
@@ -49,7 +49,14 @@ class ProcessNotificationsAction
 
     public function __invoke(string $code, Request $request): Response
     {
-        foreach ($this->notificationResolver->resolve($code, $request) as $notificationItem) {
+        try {
+            $notifications = $this->notificationResolver->resolve($code, $request);
+        } catch (NotificationItemsEmptyException) {
+            $this->logger->error('Request payload did not contain any notification items');
+            $notifications = [];
+        }
+
+        foreach ($notifications as $notificationItem) {
             if (null === $notificationItem || false === $notificationItem->success) {
                 $this->logger->error(\sprintf(
                     'Payment with pspReference [%s] did not return success',

--- a/src/Controller/Shop/ProcessNotificationsAction.php
+++ b/src/Controller/Shop/ProcessNotificationsAction.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProcessNotificationsAction
 {
-    public const EXPECTED_ADYEN_RESPONSE = '[accepted]';
+    private const EXPECTED_ADYEN_RESPONSE = '[accepted]';
 
     /** @var DispatcherInterface */
     private $dispatcher;

--- a/src/Exception/NotificationItemsEmptyException.php
+++ b/src/Exception/NotificationItemsEmptyException.php
@@ -11,6 +11,6 @@ declare(strict_types=1);
 
 namespace BitBag\SyliusAdyenPlugin\Exception;
 
-class NotificationItemsEmptyException extends \InvalidArgumentException
+final class NotificationItemsEmptyException extends \InvalidArgumentException
 {
 }

--- a/src/Resolver/Notification/NotificationResolver.php
+++ b/src/Resolver/Notification/NotificationResolver.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace BitBag\SyliusAdyenPlugin\Resolver\Notification;
 
+use BitBag\SyliusAdyenPlugin\Exception\NotificationItemsEmptyException;
 use BitBag\SyliusAdyenPlugin\Resolver\Notification\Struct\NotificationItemData;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,11 +49,12 @@ final class NotificationResolver implements NotificationResolverInterface
      */
     private function denormalizeRequestData(Request $request): array
     {
+        $result = [];
         $payload = $request->request->all();
 
         /** @var array $notificationItems */
-        $notificationItems = $payload['notificationItems'];
-        $result = [];
+        $notificationItems = $payload['notificationItems']
+            ?? throw new NotificationItemsEmptyException();
 
         /** @var array $notificationItem */
         foreach ($notificationItems as $notificationItem) {
@@ -70,7 +72,7 @@ final class NotificationResolver implements NotificationResolverInterface
     }
 
     /**
-     * @return NotificationItemData[]
+     * @inheritDoc
      */
     public function resolve(string $paymentCode, Request $request): array
     {

--- a/src/Resolver/Notification/NotificationResolverInterface.php
+++ b/src/Resolver/Notification/NotificationResolverInterface.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace BitBag\SyliusAdyenPlugin\Resolver\Notification;
 
+use BitBag\SyliusAdyenPlugin\Exception\NotificationItemsEmptyException;
 use BitBag\SyliusAdyenPlugin\Resolver\Notification\Struct\NotificationItemData;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -18,6 +19,8 @@ interface NotificationResolverInterface
 {
     /**
      * @return NotificationItemData[]
+     *
+     * @throws NotificationItemsEmptyException
      */
     public function resolve(string $paymentCode, Request $request): array;
 }

--- a/src/Resolver/Notification/Struct/NotificationRequest.php
+++ b/src/Resolver/Notification/Struct/NotificationRequest.php
@@ -16,6 +16,6 @@ class NotificationRequest
     /** @var ?bool */
     public $live;
 
-    /** @var ?NotificationItem[] */
-    public $notificationItems;
+    /** @var NotificationItem[] */
+    public $notificationItems = [];
 }

--- a/tests/Unit/Controller/Shop/ProcessNotificationsActionTest.php
+++ b/tests/Unit/Controller/Shop/ProcessNotificationsActionTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\BitBag\SyliusAdyenPlugin\Unit\Controller\Shop;
+
+use BitBag\SyliusAdyenPlugin\Bus\DispatcherInterface;
+use BitBag\SyliusAdyenPlugin\Controller\Shop\ProcessNotificationsAction;
+use BitBag\SyliusAdyenPlugin\Resolver\Notification\NotificationResolverInterface;
+use BitBag\SyliusAdyenPlugin\Resolver\Notification\NotificationToCommandResolverInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Tests\BitBag\SyliusAdyenPlugin\Unit\Mock\RequestMother;
+
+final class ProcessNotificationsActionTest extends TestCase
+{
+    public function testUndefinedNotificationItemsRequestIsHandledProperly(): void
+    {
+        $action = new ProcessNotificationsAction(
+            $this->createMock(DispatcherInterface::class),
+            $this->createMock(NotificationToCommandResolverInterface::class),
+            $this->createMock(NotificationResolverInterface::class),
+            new  NullLogger()
+        );
+
+        $response = $action('dummy-code', RequestMother::createDummy());
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('[accepted]', $response->getContent());
+    }
+}

--- a/tests/Unit/Controller/Shop/ProcessNotificationsActionTest.php
+++ b/tests/Unit/Controller/Shop/ProcessNotificationsActionTest.php
@@ -1,4 +1,12 @@
 <?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * You can find more information about us on https://bitbag.io and write us
+ * an email on hello@bitbag.io.
+ */
+
 declare(strict_types=1);
 
 namespace Tests\BitBag\SyliusAdyenPlugin\Unit\Controller\Shop;
@@ -19,7 +27,7 @@ final class ProcessNotificationsActionTest extends TestCase
             $this->createMock(DispatcherInterface::class),
             $this->createMock(NotificationToCommandResolverInterface::class),
             $this->createMock(NotificationResolverInterface::class),
-            new  NullLogger()
+            new  NullLogger(),
         );
 
         $response = $action('dummy-code', RequestMother::createDummy());

--- a/tests/Unit/Mock/RequestMother.php
+++ b/tests/Unit/Mock/RequestMother.php
@@ -18,14 +18,21 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 final class RequestMother
 {
-    public const TEST_LOCALE = 'pl_PL';
+    private const ROOT_PATH = '/';
+
+    private const TEST_LOCALE = 'pl_PL';
 
     public const WHERE_YOUR_HOME_IS = '127.0.0.1';
+
+    public static function createDummy(): Request
+    {
+        return Request::create(self::ROOT_PATH);
+    }
 
     public static function createWithSession(): Request
     {
         $session = new Session(new MockArraySessionStorage());
-        $request = Request::create('/');
+        $request = Request::create(self::ROOT_PATH);
         $request->setSession($session);
 
         return $request;
@@ -49,7 +56,7 @@ final class RequestMother
 
     public static function createWithLocaleSet(): Request
     {
-        $result = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => self::WHERE_YOUR_HOME_IS]);
+        $result = Request::create(self::ROOT_PATH, 'GET', [], [], [], ['REMOTE_ADDR' => self::WHERE_YOUR_HOME_IS]);
         $result->setLocale(self::TEST_LOCALE);
 
         return $result;

--- a/tests/Unit/Resolver/Notification/NotificationResolverTest.php
+++ b/tests/Unit/Resolver/Notification/NotificationResolverTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * You can find more information about us on https://bitbag.io and write us
+ * an email on hello@bitbag.io.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\BitBag\SyliusAdyenPlugin\Unit\Resolver\Notification;
+
+use BitBag\SyliusAdyenPlugin\Exception\NotificationItemsEmptyException;
+use BitBag\SyliusAdyenPlugin\Resolver\Notification\NotificationResolver;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Tests\BitBag\SyliusAdyenPlugin\Unit\Mock\RequestMother;
+
+final class NotificationResolverTest extends TestCase
+{
+    public function testUndefinedNotificationItemsRequestIsHandledProperly(): void
+    {
+        $resolver = new NotificationResolver(
+            $this->createMock(DenormalizerInterface::class),
+            $this->createMock(ValidatorInterface::class),
+            new NullLogger(),
+        );
+
+        $this->expectException(NotificationItemsEmptyException::class);
+
+        $resolver->resolve('dummy-payment-code', RequestMother::createDummy());
+    }
+}


### PR DESCRIPTION
Hello, this change proposal addresses a PHP warning triggered by an undefined array key "notificationItems" when invoking the Process Notifications Action

**Main changes**

* Added implementation where `notificationItems` payload may be undefined, leveraging the existing `NotificationItemsEmptyException`
* Ensured that Process Notifications Action properly manages notifications set as expected
* Hardened the initialization of NotificationRequest objects

| Before | After |
:-------------------------:|:-------------------------:
![Before the change](https://github.com/user-attachments/assets/017ad726-63fb-4526-a489-468fbf2e1547)
 | ![After the change](https://github.com/user-attachments/assets/1c6d1270-5aa7-44bb-9e7a-736a7c5189b7)

Additionally, a unit test has been added to verify this behavior