### PR TITLE
Allow for Adyen versions v12 and v13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
                 php: [ "8.0", "8.1", "8.2", "8.3" ]
                 symfony: [ "^5.4", "^6.4" ]
                 sylius: [ "^1.12", "^1.13" ]
+                adyen: [ "^11.0", "^12.0", "^13.0"]
                 node: [ "18.x", "20.x" ]
                 mysql: [ "8.0" ]
 
@@ -107,6 +108,10 @@ jobs:
                 name: Restrict Sylius version
                 if: matrix.sylius != ''
                 run: composer require "sylius/sylius:${{ matrix.sylius }}" --no-update --no-scripts --no-interaction
+            -
+                name: Restrict Adyen version
+                if: matrix.adyen != ''
+                run: composer require "adyen/php-api-library:${{ matrix.adyen }}" --no-update --no-scripts --no-interaction
 
             -
                 name: Install PHP dependencies

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0 || ^8.1",
-        "adyen/php-api-library": "^11.0",
+        "adyen/php-api-library": "^11.0 || ^12.0 || ^13.0",
         "composer/package-versions-deprecated": "^1.11",
         "nyholm/psr7": "^1.4",
         "sylius/refund-plugin": "~1.0.0 || ^1.1",


### PR DESCRIPTION
We depend on Adyen v13 and are using a fork of your v1.2.6 version for quite some time. Would be nice to have a newer Adyen version supported so we can switch back to the v2 version of your package.